### PR TITLE
Hide schools because they were creating too much noise for ej interna…

### DIFF
--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -14,6 +14,6 @@ module.exports = function (app, express) {
   // reports
   app.get('/api/reports/data', reportController.getData)
   app.get('/api/reports/pollData', reportController.pollData)
-  // reports - JSON data for earthjustice's internal use
+  // JSON data for earthjustice's internal use
   app.get('/api/reports/data/ej', reportController.getDataWrapper, reportController.getData)
 }

--- a/server/report/helpers.js
+++ b/server/report/helpers.js
@@ -1,7 +1,18 @@
+const db = require('../db')
 const {google} = require('googleapis')
 const analytics = google.analyticsreporting('v4')
-const whitelist = require('../whitelist/whitelist.json')
-
+const whitelist = {}
+const schools = ['Universities and Colleges', 'K-12 Schools']
+db.query('SELECT * from whitelist')
+    .then(result => {
+      result.rows.forEach((el) => {
+        // filter out Universities, colleges, and k-12 as per request by Christian Anthony at earthjustice
+        if (schools.indexOf(el.sector) === -1) {
+          whitelist[el.provider] = {sector: el.sector}
+        }
+      })
+    })
+    .catch(e => console.error(e))
 // ********* reportData format *********
 // *************************************
 // {

--- a/src/components/Paths.vue
+++ b/src/components/Paths.vue
@@ -45,14 +45,16 @@
       <div v-if='keySectorsSortedByProviderCountWithPathFilter.length' class='section'>
         <div class='list-header'><h2>Key Sectors</h2><h2>Count</h2></div>
         <ul>
-          <li v-for='sector in keySectorsSortedByProviderCountWithPathFilter' :key='sector'>
+          <!--Hide Universities, colleges and k12 as per request by Christian Anthony at Earthjustice-->
+          <li v-for='sector in keySectorsSortedByProviderCountWithPathFilter' :key='sector' v-if='notSchool(sector)'>
             <div>{{sector}}</div><div>{{keyProvidersBySectorWithPathFilter[sector].length}}</div>
           </li>
         </ul>
       </div>
       <h2 v-else>No page views by whitelisted providers</h2>
 
-      <div v-for='sector in keySectorsSortedByProviderCountWithPathFilter' :key='sector'>
+      <!--Hide Universities, colleges and k12 as per request by Christian Anthony at Earthjustice-->
+      <div v-for='sector in keySectorsSortedByProviderCountWithPathFilter' :key='sector' v-if='notSchool(sector)'>
         <div class='section'>
           <div class='list-header'><h2>{{sector}}</h2><h2>Seconds</h2></div>
           <ul>
@@ -92,7 +94,8 @@ import WatchlistStars from './WatchlistStars'
 export default {
   data: () => {
     return {
-      pathMsgError: 'Try editing the URL in your browser\'s address bar to search for a new path.'
+      pathMsgError: 'Try editing the URL in your browser\'s address bar to search for a new path.',
+      schools: ['Universities and Colleges', 'K-12 Schools']
     }
   },
   components: { DaysAgo, WatchlistStars },
@@ -125,6 +128,9 @@ export default {
     },
     getReportDataWithFilter () {
       this.getReportData({filter: true})
+    },
+    notSchool (sector) {
+      return this.schools.indexOf(sector) === -1
     },
     ...mapActions([
       'getReportData',


### PR DESCRIPTION
…l use
- Christian Anthony requested that schools be hidden from:
1) the app interface (i.e. the `/pages` view)
2) the API response (i.e. the JSON response from requests to `/api/reports/data/ej`)

Because they were creating too much noise. 
Schools have now been hidden from each of the above. Easy to turn them back on if requested